### PR TITLE
feat: S3 + CloudFrontを使用したフロントエンドホスティング構成を実装

### DIFF
--- a/apps/infra/lib/infra-stack.ts
+++ b/apps/infra/lib/infra-stack.ts
@@ -3,6 +3,7 @@ import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import * as s3deploy from 'aws-cdk-lib/aws-s3-deployment';
 import { Construct } from 'constructs';
 
 export class InfraStack extends cdk.Stack {
@@ -66,6 +67,14 @@ export class InfraStack extends cdk.Stack {
     });
 
     websiteBucket.addToResourcePolicy(bucketPolicyStatement);
+
+    // フロントエンドファイルをS3にデプロイ
+    new s3deploy.BucketDeployment(this, 'DeployWebsite', {
+      sources: [s3deploy.Source.asset('../frontend/dist/frontend')],
+      destinationBucket: websiteBucket,
+      distribution,
+      distributionPaths: ['/*'],
+    });
 
     // 出力
     new cdk.CfnOutput(this, 'BucketName', {

--- a/apps/infra/lib/infra-stack.ts
+++ b/apps/infra/lib/infra-stack.ts
@@ -1,16 +1,86 @@
 import * as cdk from 'aws-cdk-lib';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
+import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
-// import * as sqs from 'aws-cdk-lib/aws-sqs';
 
 export class InfraStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    // The code that defines your stack goes here
+    // S3バケットの作成（静的ウェブサイトホスティング用）
+    const websiteBucket = new s3.Bucket(this, 'WebsiteBucket', {
+      bucketName: `fav-cafe-frontend-${this.account}-${this.region}`,
+      publicReadAccess: false,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+      versioned: false,
+    });
 
-    // example resource
-    // const queue = new sqs.Queue(this, 'InfraQueue', {
-    //   visibilityTimeout: cdk.Duration.seconds(300)
-    // });
+    // CloudFrontOriginAccessControl
+    const originAccessControl = new cloudfront.S3OriginAccessControl(this, 'OriginAccessControl', {
+      description: 'Origin access control for fav-cafe frontend',
+    });
+
+    // CloudFrontディストリビューション
+    const distribution = new cloudfront.Distribution(this, 'Distribution', {
+      defaultRootObject: 'index.html',
+      defaultBehavior: {
+        origin: origins.S3BucketOrigin.withOriginAccessControl(websiteBucket, {
+          originAccessControl,
+        }),
+        compress: true,
+        allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+      },
+      errorResponses: [
+        {
+          httpStatus: 404,
+          responseHttpStatus: 200,
+          responsePagePath: '/index.html',
+          ttl: cdk.Duration.minutes(30),
+        },
+        {
+          httpStatus: 403,
+          responseHttpStatus: 200,
+          responsePagePath: '/index.html',
+          ttl: cdk.Duration.minutes(30),
+        },
+      ],
+      priceClass: cloudfront.PriceClass.PRICE_CLASS_ALL,
+    });
+
+    // S3バケットポリシーの設定（CloudFrontからのアクセスのみ許可）
+    const bucketPolicyStatement = new iam.PolicyStatement({
+      actions: ['s3:GetObject'],
+      resources: [websiteBucket.arnForObjects('*')],
+      principals: [new iam.ServicePrincipal('cloudfront.amazonaws.com')],
+      conditions: {
+        StringEquals: {
+          'AWS:SourceArn': `arn:aws:cloudfront::${this.account}:distribution/${distribution.distributionId}`,
+        },
+      },
+    });
+
+    websiteBucket.addToResourcePolicy(bucketPolicyStatement);
+
+    // 出力
+    new cdk.CfnOutput(this, 'BucketName', {
+      value: websiteBucket.bucketName,
+      description: 'Name of the S3 bucket',
+    });
+
+    new cdk.CfnOutput(this, 'DistributionId', {
+      value: distribution.distributionId,
+      description: 'CloudFront Distribution ID',
+    });
+
+    new cdk.CfnOutput(this, 'DistributionDomainName', {
+      value: distribution.distributionDomainName,
+      description: 'CloudFront Distribution Domain Name',
+    });
   }
 }

--- a/apps/infra/package.json
+++ b/apps/infra/package.json
@@ -8,7 +8,13 @@
     "build": "tsc",
     "watch": "tsc -w",
     "test": "jest",
-    "cdk": "cdk"
+    "cdk": "cdk",
+    "synth": "cdk synth",
+    "deploy": "cdk deploy --require-approval never",
+    "deploy:profile": "cdk deploy --profile",
+    "deploy:full": "cd ../frontend && pnpm build && cd ../infra && pnpm build && cdk deploy --require-approval never",
+    "diff": "cdk diff",
+    "destroy": "cdk destroy"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,15 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "infra:build": "cd apps/infra && pnpm build",
+    "infra:synth": "cd apps/infra && pnpm synth",
+    "infra:deploy": "pnpm frontend:build && pnpm infra:build && cd apps/infra && pnpm deploy",
+    "infra:deploy:only": "cd apps/infra && pnpm deploy",
+    "infra:diff": "cd apps/infra && pnpm diff",
+    "infra:destroy": "cd apps/infra && pnpm destroy",
     "frontend:start": "cd apps/frontend && pnpm start",
     "frontend:build": "cd apps/frontend && pnpm build",
-    "frontend:test": "cd apps/frontend && pnpm test"
+    "frontend:test": "cd apps/frontend && pnpm test",
+    "deploy": "pnpm infra:deploy"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- S3バケットを静的ウェブサイトホスティング用に設定
- CloudFrontディストリビューションを作成してCDN配信を有効化  
- Origin Access Controlでセキュリティを強化、SPA用エラーハンドリングを追加

## Test plan
- [ ] CDKビルドが正常に完了することを確認
- [ ] CDKデプロイが正常に実行されることを確認
- [ ] S3バケットとCloudFrontディストリビューションが正しく作成されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)